### PR TITLE
Add intermediate voters model with deduplication and derived fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The configuration mounts local directories for live development:
 [X] - Basic dbt project setup, reading CSV as duckdb pass-through source
 [X] - Airflow standalone setup
 [X] - Mount dbt project directly inside airflow container
-[X] - Build intermediate models and tests
+[X] - Build staging models and tests
+[ ] - Build intermediate models and tests
 [ ] - Add snapshot on source
 [ ] - Build dbt docs in GHA on merge
 [ ] - Build marts models and tests

--- a/dbt-ballotbox/models/intermediate/int_voters.sql
+++ b/dbt-ballotbox/models/intermediate/int_voters.sql
@@ -1,0 +1,26 @@
+with voters as (select * from {{ ref('stg_voters') }}),
+
+deduped as (
+    select
+        *, -- An example as to how we might prioritize the duplicated voter ID with
+        -- better populated fields
+        (email is not null)::int + (registered_date is not null)::int + (last_voted_date is not null)::int as non_null_cols,
+    from voters
+    qualify row_number()
+        over (partition by id order by non_null_cols desc) = 1
+)
+
+select * exclude (non_null_cols),
+
+    case
+        when age < 30 then '<29'
+        when age between 30 and 49 then '30-49'
+        when age between 50 and 64 then '50-64'
+        when age >= 65 then '65+'
+    end as age_group,
+
+    coalesce(last_voted_date = '2024-11-05'::date, false) as voted_gen24,
+
+    coalesce(last_voted_date > '2020-11-03'::date, false) as is_active
+
+from deduped

--- a/dbt-ballotbox/models/intermediate/int_voters.sql
+++ b/dbt-ballotbox/models/intermediate/int_voters.sql
@@ -1,22 +1,32 @@
-with voters as (select * from {{ ref('stg_voters') }}),
+with
+    voters as (select * from {{ ref("stg_voters") }}),
 
-deduped as (
-    select
-        *, -- An example as to how we might prioritize the duplicated voter ID with
-        -- better populated fields
-        (email is not null)::int + (registered_date is not null)::int + (last_voted_date is not null)::int as non_null_cols,
-    from voters
-    qualify row_number()
-        over (partition by id order by non_null_cols desc) = 1
-)
+    deduped as (
+        select
+            *,
+            /*
+            An example as to how we might prioritize the duplicated voter ID
+            with better populated fields
+            */
+            (email is not null)::int
+            + (registered_date is not null)::int
+            + (last_voted_date is not null)::int as non_null_cols,
+        from voters
+        qualify row_number() over (partition by id order by non_null_cols desc) = 1
+    )
 
-select * exclude (non_null_cols),
+select
+    * exclude (non_null_cols),
 
     case
-        when age < 30 then '<29'
-        when age between 30 and 49 then '30-49'
-        when age between 50 and 64 then '50-64'
-        when age >= 65 then '65+'
+        when age < 30
+        then '<29'
+        when age between 30 and 49
+        then '30-49'
+        when age between 50 and 64
+        then '50-64'
+        when age >= 65
+        then '65+'
     end as age_group,
 
     coalesce(last_voted_date = '2024-11-05'::date, false) as voted_gen24,

--- a/dbt-ballotbox/models/intermediate/schema.yml
+++ b/dbt-ballotbox/models/intermediate/schema.yml
@@ -1,0 +1,38 @@
+unit_tests:
+  - name: test_deduplication_keeps_most_populated_row
+    model: int_voters
+    given:
+      - input: ref('stg_voters')
+        rows:
+          - {id: "V001", first_name: "John", last_name: "Doe", age: 35, gender: "M", state: "CA", party: "Democrat", email: null, registered_date: null, last_voted_date: null}
+          - {id: "V001", first_name: "John", last_name: "Doe", age: 35, gender: "M", state: "CA", party: "Democrat", email: "john@example.com", registered_date: "2020-01-15", last_voted_date: "2024-11-05"}
+    expect:
+      rows:
+        - {id: "V001", first_name: "John", last_name: "Doe", age: 35, gender: "M", state: "CA", party: "Democrat", email: "john@example.com", registered_date: "2020-01-15", last_voted_date: "2024-11-05", non_null_cols: 3, age_group: "30-49", voted_gen24: true, is_active: true}
+
+models:
+  - name: int_voters
+
+    columns:
+      - name: id
+        description: Unique voter registration identifier
+        data_type: text
+        tests:
+          - not_null
+          - unique
+
+      - name: age_group
+        description: Age bracket (<29, 30-49, 50-64, 65+)
+        data_type: text
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['<29', '30-49', '50-64', '65+']
+
+      - name: voted_gen24
+        description: Whether voter cast a ballot in the 2024-11-05 general election
+        data_type: boolean
+
+      - name: is_active
+        description: Whether voter has cast at least one ballot after the 2020-11-03 general election
+        data_type: boolean

--- a/dbt-ballotbox/models/staging/stg_voters.sql
+++ b/dbt-ballotbox/models/staging/stg_voters.sql
@@ -1,26 +1,20 @@
-select 
+select
     id,
     first_name,
     last_name,
     try_cast(age as integer) as age,
 
-    case
-        when gender in ('M', 'F', 'O') then gender
-    end as gender,
+    case when gender in ('M', 'F', 'O') then gender end as gender,
 
-    case
-        when state in {{ get_state_codes() }} then state
-    end as state,
+    case when state in {{ get_state_codes() }} then state end as state,
 
     case
         when party in ('Republican', 'Democrat', 'Independent') then party
     end as party,
 
-    case
-        when {{ is_valid_email('email') }} then email
-    end as email,
+    case when {{ is_valid_email("email") }} then email end as email,
 
     try_cast(registered_date as date) as registered_date,
     try_cast(last_voted_date as date) as last_voted_date
 
-from read_csv( {{ source("voters", "voters") }}, header=True)
+from read_csv({{ source("voters", "voters") }}, header = true)

--- a/dbt-ballotbox/models/voter_counts.sql
+++ b/dbt-ballotbox/models/voter_counts.sql
@@ -1,1 +1,1 @@
-select count(*) from {{ ref('stg_voters') }}
+select count(*) from {{ ref("stg_voters") }}


### PR DESCRIPTION
## Summary

Adds intermediate layer model that dedupes voters and enriches with derived fields including age groups, voting activity flags, and participation in the gen24 election.

## Key Changes

- **Deduplication logic**: In cases where voter IDs are duplicated, prioritizes rows with more populated fields when voter IDs are duplicated
- **Age grouping**: Bucketed age ranges (<29, 30-49, 50-64, 65+)
- **Activity flags**: `voted_gen24` and `is_active` fields to track recent voting behavior
- **Unit tests**: Validates deduplication logic keeps most complete record
- **Code formatting**: Applied sqlfmt to staging and mart models

## Validation Steps

- [x] Run `dbt build` to verify unit tests and data quality checks pass